### PR TITLE
fixed parse error on composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php": ">=5.3.2"
   },
   "support": {
-    "issues": "https://github.com/christeredvartsen/php-bittorrent/issues",
+    "issues": "https://github.com/christeredvartsen/php-bittorrent/issues"
   },
   "autoload": {
     "psr-0": { "PHP\\BitTorrent": "/" }


### PR DESCRIPTION
You have a parse error on develop branch, so its not known on packagist.org:

Skipped branch develop, ""949d1dcc9f2728aa8689aef21a4ecf910a927c0e":composer.json" does not contain valid JSON
Parse error on line 18:
...ttorrent/issues",  },  "autoload": {
