### PR TITLE
we have an integer overflow on big files

### DIFF
--- a/PHP/BitTorrent/Decoder.php
+++ b/PHP/BitTorrent/Decoder.php
@@ -110,13 +110,17 @@ class Decoder implements DecoderInterface {
         }
 
         $int = substr($integer, 1, ($ePos - 1));
+
+        // force double here; 32bit int overflow on big torrents
+        settype($int, "double");
+
         $intLen = strlen($int);
 
         if (($int[0] === '0' && $intLen > 1) || ($int[0] === '-' && $int[1] === '0') || !is_numeric($int)) {
             throw new InvalidArgumentException('Invalid integer value.');
         }
 
-        return (int) $int;
+        return $int;
     }
 
     /**

--- a/PHP/BitTorrent/Encoder.php
+++ b/PHP/BitTorrent/Encoder.php
@@ -47,7 +47,7 @@ class Encoder implements EncoderInterface {
      * {@inheritDoc}
      */
     public function encode($var) {
-        if (is_int($var)) {
+        if (is_int($var) or is_double($var)) {
             return $this->encodeInteger($var);
         } else if (is_string($var)) {
             return $this->encodeString($var);
@@ -70,11 +70,11 @@ class Encoder implements EncoderInterface {
      * {@inheritDoc}
      */
     public function encodeInteger($integer) {
-        if (!is_int($integer)) {
-            throw new InvalidArgumentException('Expected integer, got: ' . gettype($integer) . '.');
+        if (is_int($integer) OR is_double($integer)) {
+            return 'i' . $integer . 'e';
         }
 
-        return 'i' . $integer . 'e';
+        throw new InvalidArgumentException('Expected integer or double, got: ' . gettype($integer) . '.');
     }
 
     /**


### PR DESCRIPTION
torrent files files >2GB dont work because of int overflow on 32bit systems. so we force double type.

before:
Array
(
    [announce] => xxxx
    [creation date] => 1354913081
    [info] => Array
        (
            [length] => 2147483647
        )

```
[name] => xxxx
[piece length] => 2097152
[pieces] =>
```

after:
   [announce] => xxx
    [creation date] => 1354913081
    [info] => Array
        (
            [length] => 14912229613
            [name] => xxx
            [piece length] => 2097152
            [pieces]
