### PR TITLE
hash and duplicate code

### DIFF
--- a/PHP/BitTorrent/Torrent.php
+++ b/PHP/BitTorrent/Torrent.php
@@ -536,11 +536,7 @@ class Torrent {
             throw new RuntimeException('Announce URL is missing.');
         }
 
-        $info = $this->getInfo();
-
-        if (empty($info)) {
-            throw new RuntimeException('The info part of the torrent is empty.');
-        }
+        $info = $this->getInfoPart();
 
         if ($encoder === null) {
             $encoder = new Encoder();
@@ -599,11 +595,7 @@ class Torrent {
      * @throws RuntimeException
      */
     public function getFileList() {
-        $info = $this->getInfo();
-
-        if ($info === null) {
-            throw new RuntimeException('The info part of the torrent is not set.');
-        }
+        $info = $this->getInfoPart();
 
         if (isset($info['length'])) {
             return $info['name'];
@@ -619,11 +611,7 @@ class Torrent {
      * @throws RuntimeException
      */
     public function getSize() {
-        $info = $this->getInfo();
-
-        if ($info === null) {
-            throw new RuntimeException('The info part of the torrent is not set.');
-        }
+        $info = $this->getInfoPart();
 
         // If the length element is set, return that one. If not, loop through the files and generate the total
         if (isset($info['length'])) {
@@ -647,13 +635,23 @@ class Torrent {
      * @throws RuntimeException
      */
     public function getName() {
-        $info = $this->getInfo();
-
-        if ($info === null) {
-            throw new RuntimeException('The info part of the torrent is not set.');
-        }
+        $info = $this->getInfoPart();
 
         return $info['name'];
+    }
+
+    /**
+     * Get the hash of the torrent file
+     *
+     * @return string The torrent hash
+     * @throws RuntimeException
+     */
+    public function getHash() {
+        $info = $this->getInfoPart();
+
+        $encoder = new Encoder();
+
+        return sha1($encoder->encodeDictionary($info));
     }
 
     /**
@@ -662,15 +660,28 @@ class Torrent {
      * @return string The torrent hash
      * @throws RuntimeException
      */
-    public function getHash() {
+    public function getEncodedHash() {
+        $info = $this->getInfoPart();
+        
+        $encoder = new Encoder();
+
+        return urlencode(sha1($encoder->encodeDictionary($info), true));
+    }
+
+    /**
+     * Get the info part of torrent and throw exception if not set
+     *
+     * @return array
+     * @throws \RuntimeException
+     */
+    private function getInfoPart() {
         $info = $this->getInfo();
 
         if ($info === null) {
             throw new RuntimeException('The info part of the torrent is not set.');
         }
 
-        $encoder = new Encoder();
-
-        return urlencode(sha1($encoder->encodeDictionary($info), true));
+        return $info;
     }
+
 }

--- a/tests/PHP/BitTorrent/TorrentTest.php
+++ b/tests/PHP/BitTorrent/TorrentTest.php
@@ -449,7 +449,7 @@ class TorrentTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @expectedException RuntimeException
-     * @expectedExceptionMessage The info part of the torrent is empty
+     * @expectedExceptionMessage The info part of the torrent is not set.
      * @covers PHP\BitTorrent\Torrent::setAnnounce
      * @covers PHP\BitTorrent\Torrent::save
      */
@@ -499,10 +499,28 @@ class TorrentTest extends \PHPUnit_Framework_TestCase {
     }
 
     /**
+     * @expectedException RuntimeException
+     * @covers PHP\BitTorrent\Torrent::getEncodedHash
+     */
+    public function testThrowsExceptionWhenTryingToGenerateEncodedHashWithEmptyTorrentFile()
+    {
+        $this->torrent->getEncodedHash();
+    }
+
+    /**
      * @covers PHP\BitTorrent\Torrent::getHash
      */
     public function testGetHash() {
         $torrent = Torrent::createFromTorrentFile(__DIR__ . '/_files/valid.torrent');
-        $this->assertSame('%C7%17%BF%D3%02%11%A5%E3l%94%CA%BA%AB%3B%3C%A0%DC%89%F9%1A', $torrent->getHash());
+        $this->assertSame('c717bfd30211a5e36c94cabaab3b3ca0dc89f91a', $torrent->getHash());
+    }
+
+    /**
+     * @covers PHP\BitTorrent\Torrent::getEncodedHash
+     */
+    public function testGetEncodedHash()
+    {
+        $torrent = Torrent::createFromTorrentFile(__DIR__ . '/_files/valid.torrent');
+        $this->assertSame('%C7%17%BF%D3%02%11%A5%E3l%94%CA%BA%AB%3B%3C%A0%DC%89%F9%1A', $torrent->getEncodedHash());
     }
 }


### PR DESCRIPTION
- removed duplicated info part exceptions
- changed hash return value to readable output to reflect torrent client visibility
- moved encoded hash to another method which can be used on the info_hash
