### PR TITLE
In the event the torrent to be parsed is in memory instead of on the

### DIFF
--- a/src/Decoder.php
+++ b/src/Decoder.php
@@ -15,7 +15,11 @@ class Decoder implements DecoderInterface {
             throw new InvalidArgumentException(sprintf('File %s does not exist or can not be read.', $file));
         }
 
-        $dictionary = $this->decodeDictionary(file_get_contents($file, true));
+        return $this->decodeFileContents(file_get_contents($file, true), $strict);
+    }
+
+    public function decodeFileContents(string $contents, bool $strict = false) : array {
+        $dictionary = $this->decodeDictionary($contents);
 
         if ($strict) {
             if (!isset($dictionary['announce']) || !is_string($dictionary['announce']) && !empty($dictionary['announce'])) {

--- a/src/DecoderInterface.php
+++ b/src/DecoderInterface.php
@@ -24,6 +24,17 @@ interface DecoderInterface {
     function decodeFile(string $file, bool $strict = false) : array;
 
     /**
+     * Decode the contents of a file as a string
+     *
+     * @param string $contents The contents of a torrent file
+     * @param bool $strict If set to true this method will check for certain elements in the
+     *                        dictionary.
+     * @return array Returns the decoded version of the file as an array
+     * @throws InvalidArgumentException
+     */
+    function decodeFileContents(string $contents, bool $strict = false) : array;
+
+    /**
      * Decode any bittorrent encoded string
      *
      * @param string $string The string to decode

--- a/src/Torrent.php
+++ b/src/Torrent.php
@@ -282,50 +282,49 @@ class Torrent {
         return (isset($info['private']) && 1 === $info['private']);
     }
 
-    static public function createFromTorrentFile(string $path, DecoderInterface $decoder = null) : self {
-        if (!is_file($path)) {
-            throw new InvalidArgumentException(sprintf('%s does not exist.', $path));
-        }
+    static public function createFromString(string $contents, DecoderInterface $decoder, bool $strict = false) : self {
+        return static::createFromDictionary($decoder->decodeFileContents($contents, $strict));
+    }
 
-        if (null === $decoder) {
-            $decoder = new Decoder();
-        }
+    static public function createFromTorrentFile(string $path, DecoderInterface $decoder, bool $strict = false) : self {
+        return static::createFromDictionary($decoder->decodeFile($path, $strict));
+    }
 
-        $decodedFile = $decoder->decodeFile($path);
+    static public function createFromDictionary(array $dictionary) : self {
         $torrent = new static();
 
-        if (isset($decodedFile['announce'])) {
-            $torrent = $torrent->withAnnounceUrl($decodedFile['announce']);
-            unset($decodedFile['announce']);
+        if (isset($dictionary['announce'])) {
+            $torrent = $torrent->withAnnounceUrl($dictionary['announce']);
+            unset($dictionary['announce']);
         }
 
-        if (isset($decodedFile['announce-list'])) {
-            $torrent = $torrent->withAnnounceList($decodedFile['announce-list']);
-            unset($decodedFile['announce-list']);
+        if (isset($dictionary['announce-list'])) {
+            $torrent = $torrent->withAnnounceList($dictionary['announce-list']);
+            unset($dictionary['announce-list']);
         }
 
-        if (isset($decodedFile['comment'])) {
-            $torrent = $torrent->withComment($decodedFile['comment']);
-            unset($decodedFile['comment']);
+        if (isset($dictionary['comment'])) {
+            $torrent = $torrent->withComment($dictionary['comment']);
+            unset($dictionary['comment']);
         }
 
-        if (isset($decodedFile['created by'])) {
-            $torrent = $torrent->withCreatedBy($decodedFile['created by']);
-            unset($decodedFile['created by']);
+        if (isset($dictionary['created by'])) {
+            $torrent = $torrent->withCreatedBy($dictionary['created by']);
+            unset($dictionary['created by']);
         }
 
-        if (isset($decodedFile['creation date'])) {
-            $torrent = $torrent->withCreatedAt($decodedFile['creation date']);
-            unset($decodedFile['creation date']);
+        if (isset($dictionary['creation date'])) {
+            $torrent = $torrent->withCreatedAt($dictionary['creation date']);
+            unset($dictionary['creation date']);
         }
 
-        if (isset($decodedFile['info'])) {
-            $torrent = $torrent->withInfo($decodedFile['info']);
-            unset($decodedFile['info']);
+        if (isset($dictionary['info'])) {
+            $torrent = $torrent->withInfo($dictionary['info']);
+            unset($dictionary['info']);
         }
 
-        if (count($decodedFile) > 0) {
-            $torrent = $torrent->withExtraMeta($decodedFile);
+        if (count($dictionary) > 0) {
+            $torrent = $torrent->withExtraMeta($dictionary);
         }
 
         return $torrent;

--- a/tests/DecoderTest.php
+++ b/tests/DecoderTest.php
@@ -175,6 +175,7 @@ class DecoderTest extends TestCase {
 
     /**
      * @covers ::decodeFile
+     * @covers ::decodeFileContents
      */
     public function testDecodeTorrentFileStrictWithMissingAnnounce() : void {
         $this->expectException(InvalidArgumentException::class);
@@ -184,6 +185,7 @@ class DecoderTest extends TestCase {
 
     /**
      * @covers ::decodeFile
+     * @covers ::decodeFileContents
      */
     public function testDecodeTorrentFileStrictWithMissingInfo() : void {
         $this->expectException(InvalidArgumentException::class);
@@ -202,6 +204,7 @@ class DecoderTest extends TestCase {
 
     /**
      * @covers ::decodeFile
+     * @covers ::decodeFileContents
      */
     public function testDecodeFileWithStrictChecksEnabled() : void {
         $list = $this->decoder->decodeFile(__DIR__ . '/_files/valid.torrent', true);


### PR DESCRIPTION
file system, allow for creation directly instead of requiring the
contents of the torrent be saved to disk first.

Modified Method Torrent\createFromTorrentFile
Created Method Decoder\decodeContents
Created Method Torrent\createFromTorrentContents
Created Method Torrent\createFromDecodeFile